### PR TITLE
Prepend single slash for namespaced function module calls

### DIFF
--- a/src/zcl_json_handler.clas.abap
+++ b/src/zcl_json_handler.clas.abap
@@ -1447,7 +1447,7 @@ method IF_HTTP_EXTENSION~HANDLE_REQUEST.
   read table p_info_tab index 2 into funcname.
   read table p_info_tab index 3 into funcname2.
   if sy-subrc eq 0.
-     concatenate '//' funcname '/' funcname2 into funcname.
+     concatenate '/' funcname '/' funcname2 into funcname.
      condense funcname.
   endif.
   translate funcname to upper case.


### PR DESCRIPTION
Before it prepend two slashes, resulting in an "invalid function" response for every call to a namespaced function module call.